### PR TITLE
Add CAPX presubmit job for eks-anywhere-build-tooling

### DIFF
--- a/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
+++ b/jobs/aws/eks-anywhere-build-tooling/cluster-api-provider-nutanix-presubmits.yaml
@@ -1,0 +1,63 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+presubmits:
+  aws/eks-anywhere-build-tooling:
+  - name: cluster-api-provider-nutanix-tooling-presubmit
+    always_run: false
+    run_if_changed: "EKS_DISTRO_MINIMAL_BASE_NONROOT_TAG_FILE|^build/lib/.*|Common.mk|projects/nutanix-cloud-native/cluster-api-provider-nutanix/.*"
+    cluster: "prow-presubmits-cluster"
+    max_concurrency: 10
+    skip_report: false
+    decoration_config:
+      gcs_configuration:
+        bucket: s3://prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+    labels:
+      image-build: "true"
+    spec:
+      serviceaccountName: presubmits-build-account
+      automountServiceAccountToken: false
+      containers:
+      - name: build-container
+        image: public.ecr.aws/eks-distro-build-tooling/builder-base:d92cba76cf18066bf37ee29dedbd3ced5b1aae86.2
+        command:
+        - bash
+        - -c
+        - >
+          trap 'touch /status/done && rm -rf /home/prow/go/src/' EXIT
+          &&
+          build/lib/buildkit_check.sh
+          &&
+          if $(make check-project-path-exists); then make build -C $PROJECT_PATH; fi
+        env:
+        - name: PROJECT_PATH
+          value: projects/nutanix-cloud-native/cluster-api-provider-nutanix
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "4"
+          limits:
+            memory: "16Gi"
+            cpu: "4"
+      - name: buildkitd
+        image: moby/buildkit:v0.10.1-rootless
+        command:
+        - sh
+        args:
+        - /script/entrypoint.sh
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000  


### PR DESCRIPTION
The presubmit builds the project path if something in the project path changes.